### PR TITLE
Konsolepartshortcuts

### DIFF
--- a/src/dolphinmainwindow.cpp
+++ b/src/dolphinmainwindow.cpp
@@ -53,6 +53,7 @@
 #include <KProtocolInfo>
 #include <KProtocolManager>
 #include <KShell>
+#include <KShortcutsDialog>
 #include <KStandardAction>
 #include <KStartupInfo>
 #include <KSycoca>
@@ -1261,7 +1262,7 @@ void DolphinMainWindow::updateHamburgerMenu()
     auto configureMenu = menu->addMenu(QIcon::fromTheme(QStringLiteral("configure")),
                             i18nc("@action:inmenu menu for configure actions", "Configure"));
     configureMenu->addAction(ac->action(KStandardAction::name(KStandardAction::SwitchApplicationLanguage)));
-    configureMenu->addAction(ac->action(KStandardAction::name(KStandardAction::KeyBindings)));
+    configureMenu->addAction(KStandardAction::keyBindings(this, SLOT(slotKeyBindings()), ac));
     configureMenu->addAction(ac->action(KStandardAction::name(KStandardAction::ConfigureToolbars)));
     configureMenu->addAction(ac->action(KStandardAction::name(KStandardAction::Preferences)));
     hamburgerMenu->hideActionsOf(configureMenu);
@@ -1374,6 +1375,19 @@ void DolphinMainWindow::slotStorageTearDownExternallyRequested(const QString& mo
         m_tearDownFromPlacesRequested = false;
         m_terminalPanel->goHome();
     }
+}
+
+void DolphinMainWindow::slotKeyBindings()
+{
+    KShortcutsDialog dialog(KShortcutsEditor::AllActions, KShortcutsEditor::LetterShortcutsAllowed, this);
+    dialog.addCollection(actionCollection());
+    if (m_terminalPanel) {
+        KActionCollection* konsolePartActionCollection = m_terminalPanel->actionCollection();
+        if (konsolePartActionCollection) {
+            dialog.addCollection(konsolePartActionCollection, QStringLiteral("KonsolePart"));
+        }
+    }
+    dialog.configure();
 }
 
 void DolphinMainWindow::setViewsToHomeIfMountPathOpen(const QString& mountPath)
@@ -2312,7 +2326,7 @@ void DolphinMainWindow::setupWhatsThis()
         "</emphasis> that covers the basics.</para>"));
 
     // Settings menu
-    actionCollection()->action(KStandardAction::name(KStandardAction::KeyBindings))
+    KStandardAction::keyBindings(this, SLOT(slotKeyBindings()), actionCollection())
         ->setWhatsThis(xi18nc("@info:whatsthis","<para>This opens a window "
         "that lists the <emphasis>keyboard shortcuts</emphasis>.<nl/>"
         "There you can set up key combinations to trigger an action when "

--- a/src/dolphinmainwindow.h
+++ b/src/dolphinmainwindow.h
@@ -576,6 +576,12 @@ private Q_SLOTS:
       * to go to.
       */
     void slotGoForward(QAction* action);
+
+    /**
+     * Is called when configuring the keyboard shortcuts
+     */
+    void slotKeyBindings();
+
 private:
     /**
      * Sets up the various menus and actions and connects them.

--- a/src/panels/terminal/terminalpanel.cpp
+++ b/src/panels/terminal/terminalpanel.cpp
@@ -6,6 +6,7 @@
 
 #include "terminalpanel.h"
 
+#include <KActionCollection>
 #include <KIO/DesktopExecParser>
 #include <KIO/Job>
 #include <KIO/JobUiDelegate>
@@ -98,6 +99,14 @@ void TerminalPanel::dockVisibilityChanged()
 QString TerminalPanel::runningProgramName() const
 {
     return m_terminal ? m_terminal->foregroundProcessName() : QString();
+}
+
+KActionCollection* TerminalPanel::actionCollection() {
+    // m_temrinal is the only reference reset to nullptr in case the terminal is closed again
+    if (m_terminal && m_konsolePart) {
+        return m_konsolePart->actionCollection();
+    }
+    return nullptr;
 }
 
 bool TerminalPanel::hasProgramRunning() const

--- a/src/panels/terminal/terminalpanel.h
+++ b/src/panels/terminal/terminalpanel.h
@@ -9,6 +9,7 @@
 
 #include "panels/panel.h"
 #include "kiofuse_interface.h"
+#include <KActionCollection>
 
 #include <QQueue>
 
@@ -47,6 +48,7 @@ public:
     bool terminalHasFocus() const;
     bool hasProgramRunning() const;
     QString runningProgramName() const;
+    KActionCollection* actionCollection();
 
 public Q_SLOTS:
     void terminalExited();


### PR DESCRIPTION
solves [bug 428265](https://bugs.kde.org/show_bug.cgi?id=428265) by essentially adapting some [changes from Yakuake](https://invent.kde.org/utilities/yakuake/-/commit/a0b08cb1f71ef18449bfbf5852c01e323604142f) (which have been used to achieve the same in Yakuake)


This is my first ever addition to kde. I've tested it on v21.12 as I was only able to build dolphin there. I was not able to build dolphin master, however rebased it to master for easier continuation of others.

I would be very happy if someone could test it with current master.
Also If anything should be adapted, I am happy to do so.

I hope this can be made to be merged into upstream in some way