### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/src/kitemviews/kitemlistview.h
+++ b/src/kitemviews/kitemlistview.h
@@ -308,7 +308,7 @@ public:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
 
     /**
-     * Set the bottom offset for moving the view so that the small overlayed statusbar
+     * Set the bottom offset for moving the view so that the small overlaid statusbar
      * won't cover any items by accident.
      */
     void setStatusBarOffset(int offset);

--- a/src/kitemviews/kitemmodelbase.h
+++ b/src/kitemviews/kitemmodelbase.h
@@ -222,7 +222,7 @@ Q_SIGNALS:
     void itemsRemoved(const KItemRangeList &itemRanges);
 
     /**
-     * Is emitted if one ore more items get moved.
+     * Is emitted if one or more items get moved.
      * @param itemRange      Item-range that gets moved to a new position.
      * @param movedToIndexes New positions for each element of the item-range.
      *

--- a/src/kitemviews/private/kitemlistviewlayouter.h
+++ b/src/kitemviews/private/kitemlistviewlayouter.h
@@ -155,7 +155,7 @@ public:
     }
 
     /**
-     * Set the bottom offset for moving the view so that the small overlayed statusbar
+     * Set the bottom offset for moving the view so that the small overlaid statusbar
      * won't cover any items by accident.
      */
     void setStatusBarOffset(int offset);

--- a/src/panels/information/informationpanel.h
+++ b/src/panels/information/informationpanel.h
@@ -18,7 +18,7 @@ class Job;
 }
 
 /**
- * @brief Panel for showing meta information of one ore more selected items.
+ * @brief Panel for showing meta information of one or more selected items.
  */
 class InformationPanel : public Panel
 {

--- a/src/settings/viewpropsprogressinfo.cpp
+++ b/src/settings/viewpropsprogressinfo.cpp
@@ -65,7 +65,7 @@ ViewPropsProgressInfo::ViewPropsProgressInfo(QWidget *parent, const QUrl &dir, c
     connect(m_dirSizeJob, &KIO::DirectorySizeJob::result, this, &ViewPropsProgressInfo::applyViewProperties);
 
     // The directory size job cannot emit any progress signal, as it is not aware
-    // about the total number of directories. Therefor a timer is triggered, which
+    // about the total number of directories. Therefore a timer is triggered, which
     // periodically updates the current directory count.
     m_timer = new QTimer(this);
     connect(m_timer, &QTimer::timeout, this, &ViewPropsProgressInfo::updateProgress);

--- a/src/tests/data/fakecomputer.xml
+++ b/src/tests/data/fakecomputer.xml
@@ -311,7 +311,7 @@
                 </device>
                     <!-- Mass Storage Interface -->
                     <device udi="/org/kde/solid/fakehw/usb_device_4e8_5041_if0">
-                        <property key="name">USB Mass Storage Inferface</property>
+                        <property key="name">USB Mass Storage Interface</property>
                         <property key="parent">/org/kde/solid/fakehw/usb_device_4e8_5041</property>
                     </device>
                         <!-- SCSI Adapter -->


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>